### PR TITLE
Add `idx explain` command for exact symbol lookup

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,8 +3,8 @@
 use clap::{Parser, Subcommand};
 
 use crate::commands::{
-    CleanCmd, ConfigCmd, IndexCmd, InitCmd, ListCmd, McpCmd, PruneCmd, RemoveCmd, RetryCmd,
-    SearchCmd, SkipCmd, StatsCmd, StatusCmd, UpdateCmd, WatchCmd,
+    CleanCmd, ConfigCmd, ExplainCmd, IndexCmd, InitCmd, ListCmd, McpCmd, PruneCmd, RemoveCmd,
+    RetryCmd, SearchCmd, SkipCmd, StatsCmd, StatusCmd, UpdateCmd, WatchCmd,
 };
 
 #[derive(Parser)]
@@ -32,6 +32,9 @@ pub enum Command {
 
     /// Search for code in indexed packages
     Search(SearchCmd),
+
+    /// Look up a symbol by name
+    Explain(ExplainCmd),
 
     /// List all indexed packages
     List(ListCmd),
@@ -72,6 +75,7 @@ impl Command {
             Command::Watch(cmd) => cmd.run().await,
             Command::Index(cmd) => cmd.run().await,
             Command::Search(cmd) => cmd.run().await,
+            Command::Explain(cmd) => cmd.run().await,
             Command::List(cmd) => cmd.run().await,
             Command::Stats(cmd) => cmd.run().await,
             Command::Status(cmd) => cmd.run().await,

--- a/src/commands/explain.rs
+++ b/src/commands/explain.rs
@@ -1,0 +1,105 @@
+//! Explain command - quick symbol lookup by name.
+
+use anyhow::{Context, Result};
+use clap::Args;
+
+use crate::local::{self, LocalSearch};
+
+#[derive(Args)]
+pub struct ExplainCmd {
+    /// Symbol name (e.g., "from_str" or "serde_json::from_str")
+    pub symbol: String,
+
+    /// Filter to specific package
+    #[arg(short, long)]
+    pub package: Option<String>,
+}
+
+impl ExplainCmd {
+    pub async fn run(&self) -> Result<()> {
+        let index_dir =
+            local::get_index_dir().context("No .index directory found. Run `idx init` first.")?;
+
+        let search = LocalSearch::new(&index_dir).await?;
+
+        // Parse symbol: "serde_json::from_str" -> (Some("serde_json"), "from_str")
+        let (pkg_hint, name) = parse_symbol(&self.symbol);
+        let package = self.package.as_deref().or(pkg_hint);
+
+        let results = search.find_by_name(name, package).await?;
+
+        if results.is_empty() {
+            println!("No symbol found matching `{}`", self.symbol);
+            println!("\nTry: idx search \"{}\"", self.symbol);
+            return Ok(());
+        }
+
+        // Show the first (best) match
+        let r = &results[0];
+
+        // Header
+        println!(
+            "{} `{}` from {}:{}@{}",
+            r.chunk_type, r.name, r.registry, r.package, r.version
+        );
+        println!("{} L{}-{}", r.file_path, r.start_line, r.end_line);
+
+        // Signature
+        if let Some(ref sig) = r.signature {
+            println!("\nSignature:");
+            println!("  {}", sig.replace('\n', "\n  "));
+        }
+
+        // Docstring
+        if let Some(ref doc) = r.docstring {
+            println!("\nDocumentation:");
+            for line in doc.lines().take(10) {
+                println!("  {}", line);
+            }
+            if doc.lines().count() > 10 {
+                println!("  ...");
+            }
+        }
+
+        // Code
+        println!("\nCode:");
+        println!("  ----------------------------------------");
+        if let Ok(code) = search.get_code(&r.storage_key).await {
+            for line in code.lines() {
+                println!("  {}", line);
+            }
+        } else {
+            for line in r.snippet.lines() {
+                println!("  {}", line);
+            }
+        }
+        println!("  ----------------------------------------");
+
+        // Other matches
+        if results.len() > 1 {
+            println!(
+                "\n{} other matches found. Use `idx search \"{}\"` to see all.",
+                results.len() - 1,
+                name
+            );
+        }
+
+        Ok(())
+    }
+}
+
+/// Parse "serde_json::from_str" into (Some("serde_json"), "from_str")
+fn parse_symbol(symbol: &str) -> (Option<&str>, &str) {
+    if let Some(pos) = symbol.rfind("::") {
+        let pkg = &symbol[..pos];
+        let name = &symbol[pos + 2..];
+        // Take root module as package hint
+        let root = pkg.split("::").next().unwrap_or(pkg);
+        (Some(root), name)
+    } else if let Some(pos) = symbol.rfind('.') {
+        // JS style: lodash.get
+        (Some(&symbol[..pos]), &symbol[pos + 1..])
+    } else {
+        (None, symbol)
+    }
+}

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -42,11 +42,8 @@ impl ListCmd {
         };
 
         if versions.is_empty() {
-            if self.status.is_some() {
-                println!(
-                    "No packages with status '{}'.",
-                    self.status.as_ref().unwrap()
-                );
+            if let Some(status) = &self.status {
+                println!("No packages with status '{}'.", status);
             } else {
                 println!("No packages indexed yet. Run `idx init` to index your dependencies.");
             }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,6 +2,7 @@
 
 mod clean;
 mod config;
+mod explain;
 mod index;
 mod init;
 mod list;
@@ -18,6 +19,7 @@ mod watch;
 
 pub use clean::CleanCmd;
 pub use config::ConfigCmd;
+pub use explain::ExplainCmd;
 pub use index::IndexCmd;
 pub use init::InitCmd;
 pub use list::ListCmd;

--- a/src/local/db.rs
+++ b/src/local/db.rs
@@ -563,6 +563,54 @@ impl LocalDb {
         Ok(namespaces)
     }
 
+    /// Find chunks by exact symbol name, with optional package filter.
+    pub async fn find_by_name(
+        &self,
+        name: &str,
+        package: Option<&str>,
+    ) -> Result<Vec<ChunkWithPackage>> {
+        let rows = if let Some(pkg) = package {
+            sqlx::query_as::<_, ChunkWithPackage>(
+                r#"
+                SELECT
+                    c.id, c.namespace, c.chunk_type, c.name, c.file_path,
+                    c.start_line, c.end_line, c.visibility, c.signature,
+                    c.docstring, c.snippet, c.storage_key,
+                    p.registry, p.name as package_name, v.version
+                FROM chunks c
+                JOIN versions v ON c.version_id = v.id
+                JOIN packages p ON v.package_id = p.id
+                WHERE c.name = ? AND p.name = ?
+                ORDER BY v.indexed_at DESC
+                "#,
+            )
+            .bind(name)
+            .bind(pkg)
+            .fetch_all(&self.pool)
+            .await?
+        } else {
+            sqlx::query_as::<_, ChunkWithPackage>(
+                r#"
+                SELECT
+                    c.id, c.namespace, c.chunk_type, c.name, c.file_path,
+                    c.start_line, c.end_line, c.visibility, c.signature,
+                    c.docstring, c.snippet, c.storage_key,
+                    p.registry, p.name as package_name, v.version
+                FROM chunks c
+                JOIN versions v ON c.version_id = v.id
+                JOIN packages p ON v.package_id = p.id
+                WHERE c.name = ?
+                ORDER BY v.indexed_at DESC
+                "#,
+            )
+            .bind(name)
+            .fetch_all(&self.pool)
+            .await?
+        };
+
+        Ok(rows)
+    }
+
     // ==================== Stats ====================
 
     /// Get index statistics.

--- a/src/local/search.rs
+++ b/src/local/search.rs
@@ -118,6 +118,36 @@ impl LocalSearch {
         String::from_utf8(bytes).context("Invalid UTF-8 in stored code")
     }
 
+    /// Find symbols by exact name match.
+    pub async fn find_by_name(
+        &self,
+        name: &str,
+        package: Option<&str>,
+    ) -> Result<Vec<SearchResult>> {
+        let chunks = self.db.find_by_name(name, package).await?;
+
+        Ok(chunks
+            .into_iter()
+            .map(|c| SearchResult {
+                id: c.id,
+                registry: c.registry,
+                package: c.package_name,
+                version: c.version,
+                chunk_type: c.chunk_type,
+                name: c.name,
+                file_path: c.file_path,
+                start_line: c.start_line as u32,
+                end_line: c.end_line as u32,
+                visibility: c.visibility,
+                signature: c.signature,
+                docstring: c.docstring,
+                snippet: c.snippet,
+                storage_key: c.storage_key,
+                score: 1.0, // exact match
+            })
+            .collect())
+    }
+
     /// Generate embedding for a query.
     async fn embed(&self, text: &str) -> Result<Vec<f32>> {
         let api_key = self


### PR DESCRIPTION
## Summary
- Adds `idx explain <symbol>` command that looks up a symbol by exact name
- Supports `pkg::symbol` (Rust) and `pkg.symbol` (JS) notation as a package filter hint
- Prints signature, docstring (up to 10 lines), and full source from blob storage

## Test plan
- [ ] `idx explain from_str` — finds all `from_str` symbols across indexed packages
- [ ] `idx explain serde_json::from_str` — filters to serde_json package
- [ ] `idx explain nonexistent` — graceful "not found" with suggestion to use `idx search`
- [ ] `--package` flag overrides/supplements the parsed hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)